### PR TITLE
Fix for us-east-1

### DIFF
--- a/JumpCloudImporter.py
+++ b/JumpCloudImporter.py
@@ -930,8 +930,12 @@ exit 0
                 file_name, bucket, object_name, Callback=ProgressPercentage(file_name))
             location = boto3.client('s3').get_bucket_location(
                 Bucket=bucket)['LocationConstraint']
-            url = "https://s3-%s.amazonaws.com/%s/%s" % (
-                location, bucket, quote(object_name))
+            if location is None:
+	        location_url = "" 
+            else:
+	        location_url = "-%s" % (location)
+            url = "https://s3%s.amazonaws.com/%s/%s" % (
+                location_url, bucket, quote(object_name))
             self.commandUrl = url
             print("\nUploaded File at URL: " + url)
         except ClientError as e:


### PR DESCRIPTION
Location returns null for us-east-1 see https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/get-bucket-location.html#output

Ideally it would be great if this could be updated to support JumpCloud Software Management as that would be a better way to manage packages with the MDM. 